### PR TITLE
feat: fetch JWT certificate from JWKS endpoint to fix session expiration issue

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,15 +16,22 @@ package config
 
 import (
 	_ "embed"
+	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
-	"io/ioutil"
+	"encoding/pem"
+	"fmt"
+	"io"
 	"log"
+	"net/http"
+	"os"
+	"time"
 
 	"github.com/casdoor/casdoor-go-sdk/auth"
 )
 
 //go:embed token.pem
-var CasdoorJwtSecret string
+var EmbeddedJwtSecret string
 
 type Config struct {
 	CasdoorEndpoint     string `json:"casdoorEndpoint"`
@@ -37,8 +44,85 @@ type Config struct {
 
 var CurrentConfig Config
 
+// JWKSResponse represents the JWKS endpoint response
+type JWKSResponse struct {
+	Keys []JWK `json:"keys"`
+}
+
+// JWK represents a JSON Web Key
+type JWK struct {
+	Kid string   `json:"kid"`
+	X5c []string `json:"x5c"`
+}
+
+// fetchCertificateFromJWKS fetches the certificate from Casdoor's JWKS endpoint.
+// This ensures the auth service always uses the correct certificate that matches
+// the Casdoor instance, regardless of when the certificate was generated.
+func fetchCertificateFromJWKS(endpoint string) (string, error) {
+	jwksURL := fmt.Sprintf("%s/.well-known/jwks", endpoint)
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(jwksURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch JWKS: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("JWKS endpoint returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read JWKS response: %w", err)
+	}
+
+	var jwks JWKSResponse
+	if err := json.Unmarshal(body, &jwks); err != nil {
+		return "", fmt.Errorf("failed to parse JWKS: %w", err)
+	}
+
+	// Find the cert-built-in key or use the first available key
+	var x5c string
+	for _, key := range jwks.Keys {
+		if len(key.X5c) > 0 {
+			if key.Kid == "cert-built-in" {
+				x5c = key.X5c[0]
+				break
+			}
+			if x5c == "" {
+				x5c = key.X5c[0] // fallback to first key with x5c
+			}
+		}
+	}
+
+	if x5c == "" {
+		return "", fmt.Errorf("no x5c certificate found in JWKS")
+	}
+
+	// Convert base64 DER to PEM format
+	derBytes, err := base64.StdEncoding.DecodeString(x5c)
+	if err != nil {
+		return "", fmt.Errorf("failed to decode x5c: %w", err)
+	}
+
+	// Parse to verify it's a valid certificate
+	cert, err := x509.ParseCertificate(derBytes)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse certificate: %w", err)
+	}
+
+	// Encode as PEM
+	pemBlock := &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert.Raw,
+	}
+
+	return string(pem.EncodeToMemory(pemBlock)), nil
+}
+
 func LoadConfigFile(path string) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		log.Fatalf("failed to read config file %s", path)
 	}
@@ -48,11 +132,22 @@ func LoadConfigFile(path string) {
 		log.Fatalf("failed to unmarshal config file %s: %s", path, err.Error())
 	}
 
+	// Try to fetch certificate from JWKS endpoint first.
+	// This ensures we always use the correct certificate from the actual Casdoor instance,
+	// which fixes the issue where embedded token.pem doesn't match the deployed Casdoor's certificate.
+	jwtSecret := EmbeddedJwtSecret
+	if fetchedCert, err := fetchCertificateFromJWKS(CurrentConfig.CasdoorEndpoint); err == nil {
+		log.Printf("Successfully fetched certificate from JWKS endpoint")
+		jwtSecret = fetchedCert
+	} else {
+		log.Printf("Warning: Failed to fetch certificate from JWKS (%v), falling back to embedded certificate", err)
+	}
+
 	auth.InitConfig(
 		CurrentConfig.CasdoorEndpoint,
 		CurrentConfig.CasdoorClientId,
 		CurrentConfig.CasdoorClientSecret,
-		CasdoorJwtSecret,
+		jwtSecret,
 		CurrentConfig.CasdoorOrganization,
 		CurrentConfig.CasdoorApplication,
 	)


### PR DESCRIPTION
## Problem

The embedded `token.pem` contains a certificate that was generated during the original project development. However, **each Casdoor deployment generates its own unique `cert-built-in` certificate** when the database is first initialized.

This certificate mismatch causes JWT signature verification to always fail, which leads to a critical user experience issue:

### Symptom
Users are forced to re-authenticate frequently (e.g., every 30 minutes or less), even though the Casdoor application is configured with a much longer token expiration time (e.g., 168 hours / 7 days).

### Root Cause
When JWT signature verification fails due to certificate mismatch, the auth middleware cannot validate the token and redirects users to the login page. This makes the `expireInHours` setting in Casdoor effectively useless.

### Why This Happens
1. The `token.pem` in this repository was generated on **Oct 15, 2021** (the original developer's Casdoor instance)
2. Any new Casdoor deployment generates a fresh `cert-built-in` certificate
3. The two certificates will never match unless users manually replace `token.pem` (which is not documented)

## Solution

Fetch the JWT certificate dynamically from Casdoor's standard OIDC JWKS endpoint (`/.well-known/jwks`) at service startup. This ensures the auth service always uses the correct certificate that matches the actual Casdoor instance.

### Changes
- Add `fetchCertificateFromJWKS()` function to retrieve certificate from JWKS endpoint
- Try JWKS fetch first at startup, fall back to embedded certificate if unavailable
- Rename `CasdoorJwtSecret` to `EmbeddedJwtSecret` to clarify its role as fallback
- Replace deprecated `ioutil.ReadFile` with `os.ReadFile`

### Backward Compatibility
- The embedded `token.pem` is retained as a fallback
- No configuration changes required
- Existing deployments will automatically start working correctly after upgrade

## Testing
Verified in production environment:
```
2026/01/09 11:26:29 Successfully fetched certificate from JWKS endpoint
```

Sessions now correctly respect the Casdoor-configured expiration time.